### PR TITLE
Update node-install.sh

### DIFF
--- a/install-node.sh
+++ b/install-node.sh
@@ -16,7 +16,7 @@ fi
 # Setting Environment Varaibles
 echo "Setting environment variables..."
 echo "export NODE_ENV=development" >> /home/vagrant/.bashrc
-echo "\ncd /vagrant" >> /home/vagrant/.bashrc
+echo "cd /vagrant" >> /home/vagrant/.bashrc
 
 # Installing nvm
 echo "Installing nvm..."


### PR DESCRIPTION
This fixes the intended purpose of this line (user should automatically enter /vagrant directory). It also removes the error  "ncd command not found" when starting a new machine.
